### PR TITLE
feat: basis spinless fermions terms

### DIFF
--- a/pystrel/terms/__init__.py
+++ b/pystrel/terms/__init__.py
@@ -1,6 +1,15 @@
 r"""
 ## Supported terms
 
+**Spinless fermions**
+
+| tag          | Operator                                                                         |
+|--------------|----------------------------------------------------------------------------------|
+| `t`          | $\sum_{i,j} \left(t_{ij} \, a_i^\dagger a_j + \text{h.c.}\right)$                |
+| `V`          | $\sum_{i,j} V_{ij} \, n_i n_j$                                                   |
+| `Delta`      | $\sum_{i,j} \left(\Delta_{ij} \, a_i^\dagger a_j^\dagger + \text{h.c.}\right)$   |
+| `mu`         | $\sum_{i} \mu_{i} \, n_i$                                                        |
+
 **Spins 1/2**
 
 | tag          | Operator                                                                         |

--- a/pystrel/terms/impl.py
+++ b/pystrel/terms/impl.py
@@ -113,4 +113,117 @@ class Term_hx(Term):
                     matrix[x, y] += gamma
         return matrix
 
+
+class Term_t(Term):
+    r"""
+    Implementation of the hopping operator tᵢⱼ a†ᵢaⱼ for
+    spinless fermions, given by
+
+    $$
+    \sum_{i,j} \left(t_{ij} \, a_i^\dagger a_j + \text{h.c.}\right).
+    $$
+    """
+    tag = 't'
+    particle_type = 'spinless fermions'
+    ensemble = 'canonical'
+    repr = '∑ᵢⱼ (tᵢⱼ a†ᵢaⱼ + h.c.)'
+    mixing_rank = 0
+
+    @staticmethod
+    def apply(params, matrix, sector):
+        for x in range(matrix.shape[0]):
+            s0 = combinadics.tostate(x, sector[0], sector[1])
+            for (i, j), t in params.items():
+                if s0[i] == '1' and s0[j] == '0':
+                    s1 = s0[:i] + '0' + s0[i+1:]
+                    s1 = s1[:j] + '1' + s1[j+1:]
+                    y = combinadics.tonumber(s1)
+                    sign = (-1.0)**combinadics.count_particles_between(s0, i, j)
+                    if x < y:
+                        matrix[x, y] += sign * t
+                    else:
+                        matrix[y, x] += sign * np.conj(t)
+        return matrix
+
+
+class Term_V(Term):
+    r"""
+    Implementation of the 2-body operator Vᵢⱼ nᵢnⱼ for
+    spinless fermions, given by
+
+    $$
+    \sum_{i,j} V_{ij} \, n_i n_j.
+    $$
+    """
+    tag = 'V'
+    particle_type = 'spinless fermions'
+    ensemble = 'canonical'
+    repr = '∑ᵢⱼ Vᵢⱼ nᵢnⱼ'
+    mixing_rank = 0
+
+    @staticmethod
+    def apply(params, matrix, sector):
+        for x in range(matrix.shape[0]):
+            s = combinadics.tostate(x, sector[0], sector[1])
+            for (i, j), V in params.items():
+                if s[i] == '1' and s[j] == '1':
+                    matrix[x, x] += V
+        return matrix
+
+
+class Term_Delta(Term):
+    r"""
+    Implementation of the pair operator Δᵢⱼ a†ᵢa†ⱼ for
+    spinless fermions, given by
+
+    $$
+    \sum_{i,j} \left(\Delta_{ij} \, a_i^\dagger a_j^\dagger + \text{h.c.}\right).
+    $$
+    """
+    tag = 'Delta'
+    particle_type = 'spinless fermions'
+    ensemble = 'parity grand canonical'
+    repr = '∑ᵢⱼ (Δᵢⱼ a†ᵢa†ⱼ + h.c.)'
+    mixing_rank = 2
+
+    @staticmethod
+    def apply(params, matrix, sector):
+        for x in range(matrix.shape[0]):
+            s0 = combinadics.tostate(x, sector[0], sector[1])
+            for (i, j), Delta in params.items():
+                if s0[i] == '0' and s0[j] == '0':
+                    s1 = s0[:i] + '1' + s0[i+1:]
+                    s1 = s1[:j] + '1' + s1[j+1:]
+                    y = combinadics.tonumber(s1)
+                    sign = (-1.0)**combinadics.count_particles_between(s0, i, j)
+                    sign = sign if i < j else -sign
+                    matrix[x, y] += sign * Delta
+        return matrix
+
+
+class Term_mu(Term):
+    r"""
+    Implementation of chemical potential like operator μᵢ nᵢ for
+    spinless fermions, given by
+
+    $$
+    \sum_{i} \mu_{i} \, n_i .
+    $$
+    """
+    tag = 'mu'
+    particle_type = 'spinless fermions'
+    ensemble = 'canonical'
+    repr = '∑ᵢ μᵢ nᵢ'
+    mixing_rank = 0
+
+    @staticmethod
+    def apply(params, matrix, sector):
+        for x in range(matrix.shape[0]):
+            s = combinadics.tostate(x, sector[0], sector[1])
+            for i, mu in params.items():
+                if s[i] == '1':
+                    matrix[x, x] += mu
+        return matrix
+
+
 # pylint: enable=C0103, R0903


### PR DESCRIPTION
Add implementation of the basic spinless fermions terms, including:

- Hopping term (t): $t_{ij}a_i^\dagger a_j + \text{h.c.}$,
- Chemical potential (mu): $\mu_i n_i$,
- Many-body interaction (V): $V_{ij} n_i n_j$,
- Pairing term (delta): $\Delta_{ij} a_i^\dagger a_j^\dagger + \text{h.c.}$.