### PR TITLE
chore: fix coverage target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: flit install
 
       - name: Run tests
-        run: pytest --cov
+        run: pytest --cov=pystrel
 
       - name: Run pylint
         run: pylint pystrel/ tests/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: docs
 
 test:
-	pytest --cov
+	pytest --cov=pystrel
 	mypy
 	pylint pystrel/ tests/
 	black --check .


### PR DESCRIPTION
Explicitly show the module name `pystrel`. Before commit, the coverage takes into account `tests` folder as well.