### PR TITLE
feat: sectors helper class

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -53,44 +53,6 @@ ps.terms.utils.register_term_type(FakeB)
 ps.terms.utils.register_term_type(FakeC)
 
 
-@pytest.mark.parametrize(
-    "params, expected",
-    [
-        ({"sites": 4, "particles": 2, "terms": {"fake A": {(0, 1): 1.0}}}, [(4, 2)]),
-        (
-            {"sites": 4, "terms": {"fake B": {(0, 1): 1.0}}},
-            [(4, 0), (4, 1), (4, 2), (4, 3), (4, 4)],
-        ),
-        (
-            {"sites": 4, "parity": 0, "terms": {"fake C": {(0, 1): 1.0}}},
-            [(4, 0), (4, 2), (4, 4)],
-        ),
-    ],
-)
-def test_model_init_sectors(params, expected):
-    model = ps.Model(params)
-    assert model.sectors == expected
-
-
-@pytest.mark.parametrize(
-    "params, expected",
-    [
-        ({"sites": 4, "particles": 2, "terms": {"fake A": {(0, 1): 1.0}}}, []),
-        (
-            {"sites": 4, "terms": {"fake B": {(0, 1): 1.0}}},
-            [(0, 1), (1, 2), (2, 3), (3, 4)],
-        ),
-        (
-            {"sites": 4, "parity": 0, "terms": {"fake C": {(0, 1): 1.0}}},
-            [(0, 1), (1, 2)],
-        ),
-    ],
-)
-def test_model_init_mixing_sectors(params, expected):
-    model = ps.Model(params)
-    assert model.mixing_sectors == expected
-
-
 def test_model_build_hamiltonian_case1():
     params = {
         "sites": 2,

--- a/tests/test_sectors.py
+++ b/tests/test_sectors.py
@@ -1,5 +1,121 @@
 import pytest
+import numpy as np
 import pystrel.sectors as ps
+
+# pylint: disable=R0903,C0115,R0801
+
+
+class FakeSectorsA(ps.terms.Term):
+    tag = "fake sectors A"
+    repr = "Fake repr 0"
+    mixing_rank = 0
+    particle_type = "spinless fermions"
+    ensemble = "canonical"
+
+    @staticmethod
+    def apply(params: dict, matrix: np.ndarray, sector: tuple[int, int]):
+        matrix[:] += 1.0
+        return np.triu(matrix)
+
+
+class FakeSectorsB(ps.terms.Term):
+    tag = "fake sectors B"
+    repr = "Fake repr 1"
+    mixing_rank = 1
+    particle_type = "spinfull fermions"
+    ensemble = "grand canonical"
+
+    @staticmethod
+    def apply(params: dict, matrix: np.ndarray, sector: tuple[int, int]):
+        matrix[:] += 2.0
+        return matrix
+
+
+class FakeSectorsC(ps.terms.Term):
+    tag = "fake sectors C"
+    repr = "Fake repr 2"
+    mixing_rank = 2
+    particle_type = "spins 1/2"
+    ensemble = "parity grand canonical"
+
+    @staticmethod
+    def apply(params: dict, matrix: np.ndarray, sector: tuple[int, int]):
+        matrix[:] += 4.0
+        return matrix
+
+
+# pylint: enable=R0903,C0115,R0801
+
+
+ps.terms.utils.register_term_type(FakeSectorsA)
+ps.terms.utils.register_term_type(FakeSectorsB)
+ps.terms.utils.register_term_type(FakeSectorsC)
+
+
+@pytest.mark.parametrize(
+    "params, expected",
+    [
+        (
+            {"sites": 4, "particles": 2, "terms": {"fake sectors A": {(0, 1): 1.0}}},
+            [(4, 2)],
+        ),
+        (
+            {"sites": 4, "terms": {"fake sectors B": {(0, 1): 1.0}}},
+            [(4, 0), (4, 1), (4, 2), (4, 3), (4, 4)],
+        ),
+        (
+            {"sites": 4, "parity": 0, "terms": {"fake sectors C": {(0, 1): 1.0}}},
+            [(4, 0), (4, 2), (4, 4)],
+        ),
+    ],
+)
+def test_sectors_sectors_collection(params, expected):
+    sectors = ps.Sectors(params)
+    assert sectors.sectors == expected
+
+
+@pytest.mark.parametrize(
+    "params, expected",
+    [
+        ({"sites": 4, "particles": 2, "terms": {"fake sectors A": {(0, 1): 1.0}}}, []),
+        (
+            {"sites": 4, "terms": {"fake sectors B": {(0, 1): 1.0}}},
+            [(0, 1), (1, 2), (2, 3), (3, 4)],
+        ),
+        (
+            {"sites": 4, "parity": 0, "terms": {"fake sectors C": {(0, 1): 1.0}}},
+            [(0, 1), (1, 2)],
+        ),
+    ],
+)
+def test_sectors_mixing_sectors_collection(params, expected):
+    sectors = ps.Sectors(params)
+    assert sectors.mixing_sectors == expected
+
+
+def test_sectors_str():
+    sectors = ps.Sectors({"sectors": [(4, 1), (4, 3)]})
+    assert str(sectors) == "[(4, 1), (4, 3)]"
+
+
+def test_sectors_iter():
+    sectors = ps.Sectors({"sectors": [(3, 0), (3, 1), (3, 2), (3, 3)]})
+    assert list(sectors) == [
+        (0, 1, (3, 0)),
+        (1, 4, (3, 1)),
+        (4, 7, (3, 2)),
+        (7, 8, (3, 3)),
+    ]
+
+
+def test_sectors_mixing_iter():
+    sectors = ps.Sectors(
+        {"terms": {"fake sectors B": {}}, "sectors": [(2, 0), (2, 1), (2, 2)]}
+    )
+    assert list(sectors.mixing_iter()) == [
+        ((0, 1, (2, 0)), (1, 3, (2, 1))),
+        ((1, 3, (2, 1)), (3, 4, (2, 2))),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -60,6 +176,6 @@ def test_generate_sectors(ensemble, params, expected):
         ([1, 2], [(10, 1), (10, 2), (10, 3)], [(0, 1), (0, 2), (1, 2)]),
     ],
 )
-def test_(ranks, sectors, expected):
+def test_generate_mixing_sectors(ranks, sectors, expected):
     mixing_sectors = ps.generate_mixing_sectors(ranks, sectors)
     assert mixing_sectors == expected


### PR DESCRIPTION
This commit introduces a new helper class called `Sectors` that facilitates working with sectors in the Hilbert space. The `Sectors` class is designed to simplify iterations over sectors, making them more convenient to handle.