### PR TITLE
fix: mu term sparse support

### DIFF
--- a/pystrel/terms/impl.py
+++ b/pystrel/terms/impl.py
@@ -2,6 +2,7 @@
 All `pystrel.terms.term.Term` implementations.
 """
 import numpy as np
+import scipy.sparse as nps  # type: ignore
 from .. import combinadics
 from .term import Term
 
@@ -243,7 +244,13 @@ class Term_mu(Term):
 
     @staticmethod
     def apply(params, matrix, sector):
-        np.fill_diagonal(matrix, matrix.diagonal() + params * sector[1])
+        if isinstance(matrix, np.ndarray):
+            np.fill_diagonal(matrix, matrix.diagonal() + params * sector[1])
+
+        elif isinstance(matrix, nps.dok_array):
+            diagonal = range(matrix.shape[0])
+            matrix[diagonal, diagonal] += params * sector[1]
+
         return matrix
 
 

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -6,9 +6,9 @@ We could introduce abstraction for the combinadics, however, this is not worth t
 import pytest
 import numpy as np
 import numpy.testing as npt
+import scipy.sparse as nps  # type: ignore
 import scipy.special as sps  # type: ignore
 import pystrel.terms as ps
-
 
 # pylint: disable=R0903,C0115,R0801
 
@@ -328,5 +328,19 @@ def test_term_mu():
 
     matrix = ps.Term_mu.apply(params, matrix, (L, N))
     eig = np.linalg.eigvalsh(matrix, "U")
+
+    npt.assert_array_equal(eig, [4.0, 5, 6, 7, 8, 9])
+
+
+def test_term_mu_sparse():
+    L = 4
+    N = 2
+    size = int(sps.binom(L, N))
+    params = 2.0
+    matrix = nps.dok_array((size, size))
+    matrix.setdiag(np.arange(size))
+
+    matrix = ps.Term_mu.apply(params, matrix, (L, N))
+    eig = np.linalg.eigvalsh(matrix.toarray(), "U")
 
     npt.assert_array_equal(eig, [4.0, 5, 6, 7, 8, 9])


### PR DESCRIPTION
Fix a bug which throws an exception when one tries to use `mu` term for sparse matrix.