### PR TITLE
refactor: replace dok matrix with dok array

### DIFF
--- a/pystrel/model.py
+++ b/pystrel/model.py
@@ -58,7 +58,7 @@ class Model:
         device: typing.Literal["cpu", "gpu"] = "cpu",
         sparsity: typing.Literal["sparse", "dense"] = "dense",
         dtype: npt.DTypeLike = None,
-    ) -> np.ndarray | nps.csr_matrix | typing.Any:
+    ) -> np.ndarray | nps.csr_array | typing.Any:
         """
         Constructs hamiltonian on the selected `device` and matrix `sparsity` type.
 
@@ -74,7 +74,7 @@ class Model:
 
         Returns
         -------
-        np.ndarray | nps.csr_matrix | Any
+        np.ndarray | nps.csr_array | Any
             Hamiltonian matrix representation.
 
         Raises
@@ -103,10 +103,10 @@ class Model:
                 raise ValueError()
 
             case "sparse":
-                matrix = nps.dok_matrix(shape, dtype=dtype)
+                matrix = nps.dok_array(shape, dtype=dtype)
                 self.__build_local_sectors(matrix)
                 self.__build_mixing_sectors(matrix)
-                matrix = nps.csr_matrix(matrix + nps.triu(matrix, 1).H)
+                matrix = nps.csr_array(matrix + nps.triu(matrix, 1).H)
                 if device == "cpu":
                     return matrix
                 if device == "gpu":
@@ -116,7 +116,7 @@ class Model:
             case _:
                 raise ValueError()
 
-    def __build_local_sectors(self, matrix: np.ndarray | nps.dok_matrix):
+    def __build_local_sectors(self, matrix: np.ndarray | nps.dok_array):
         for start, end, sector in self.sectors:
             matrix[start:end, start:end] = terms.utils.apply(
                 terms=self.terms,
@@ -125,7 +125,7 @@ class Model:
                 rank=0,
             )
 
-    def __build_mixing_sectors(self, matrix: np.ndarray | nps.dok_matrix):
+    def __build_mixing_sectors(self, matrix: np.ndarray | nps.dok_array):
         for (start0, end0, sector0), (
             start1,
             end1,

--- a/pystrel/terms/term.py
+++ b/pystrel/terms/term.py
@@ -18,7 +18,7 @@ class Term:  # pylint: disable=R0903
 
     @staticmethod  # pylint: disable=W0613
     def apply(
-        params: dict, matrix: np.ndarray | nps.dok_matrix, sector: tuple[int, int]
+        params: dict, matrix: np.ndarray | nps.dok_array, sector: tuple[int, int]
     ):
         """
         Applies terms on given `matrix` using `params`.
@@ -30,7 +30,7 @@ class Term:  # pylint: disable=R0903
         ----------
         params : dict
             Dictionary of given parameters, e.g. `{(0, 1): 1.0, (1, 2): 2.0}`.
-        matrix : npt.ndarray | nps.dok_matrix
+        matrix : npt.ndarray | nps.dok_array
             View on matrix on which terms should be applied.
         sector : tuple[int, int]
             Corresponding particle sector for given `matrix`.

--- a/pystrel/terms/utils.py
+++ b/pystrel/terms/utils.py
@@ -126,10 +126,10 @@ def collect_mixing_sector_ranks(terms: dict[str, dict]) -> set[int]:
 
 def apply(
     terms: dict[str, dict],
-    matrix: np.ndarray | nps.dok_matrix,
+    matrix: np.ndarray | nps.dok_array,
     sector: tuple[int, int],
     rank: int,
-) -> np.ndarray | nps.dok_matrix:
+) -> np.ndarray | nps.dok_array:
     """
     Applies all `terms` of given `rank` on `matrix` within given `sector`.
 
@@ -146,7 +146,7 @@ def apply(
 
     Returns
     -------
-    np.ndarray | nps.dok_matrix
+    np.ndarray | nps.dok_array
         Matrix with applied terms.
     """
     for t, params in terms.items():


### PR DESCRIPTION
`Scipy.sparse` declares that `dok_matrix` should be replaced with `dok_array`, which is more compatible with `numpy.ndarray`.