### PR TITLE
feat: operators module

### DIFF
--- a/pystrel/__init__.py
+++ b/pystrel/__init__.py
@@ -2,5 +2,6 @@
 from .model import Model
 from . import combinadics
 from . import terms
+from . import operators
 
 __version__ = "0.0.0"

--- a/pystrel/operators/__init__.py
+++ b/pystrel/operators/__init__.py
@@ -1,0 +1,12 @@
+r"""
+## Supported operators
+
+| tag          | operator       |        name                        | `kwargs`        |
+|--------------|----------------|------------------------------------|-----------------|
+| `H`          | $H$            | Hamiltonian                        |   None          |
+| `N`          | $N=\sum_i n_i$ | total particle number operator     |   None          |
+| `n`          | $n_i$          | particle number operator           | `i`: site index |
+
+"""
+from .impl import *
+from . import utils

--- a/pystrel/operators/hermitian_operator.py
+++ b/pystrel/operators/hermitian_operator.py
@@ -1,0 +1,93 @@
+"""
+Module with generic utility for hermitian operator construction.
+"""
+import typing
+import numpy as np
+import numpy.typing as npt
+import scipy.sparse as nps  # type: ignore
+
+from ..sectors import Sectors
+from ..terms import utils as terms_utils
+
+
+class HermitianOperator:  # pylint: disable=R0903
+    """Hermitian operator implementation"""
+
+    @staticmethod
+    def __build_local_sectors(
+        sectors: Sectors, terms: dict, matrix: np.ndarray | nps.dok_array
+    ):
+        for start, end, sector in sectors:
+            matrix[start:end, start:end] = terms_utils.apply(
+                terms=terms,
+                matrix=matrix[start:end, start:end],
+                sector=sector,
+                rank=0,
+            )
+
+    @staticmethod
+    def __build_mixing_sectors(
+        sectors: Sectors, terms: dict, matrix: np.ndarray | nps.dok_array
+    ):
+        for (start0, end0, sector0), (
+            start1,
+            end1,
+            sector1,
+        ) in sectors.mixing_iter():
+            matrix[start0:end0, start1:end1] = terms_utils.apply(
+                terms=terms,
+                matrix=matrix[start0:end0, start1:end1],
+                sector=sector0,
+                rank=sector1[1] - sector0[1],
+            )
+
+    @staticmethod
+    def build(
+        sectors: Sectors,
+        terms: dict,
+        sparsity: typing.Literal["sparse", "dense"] = "dense",
+        dtype: npt.DTypeLike = None,
+    ) -> np.ndarray | nps.csr_array:
+        """
+        Construct hermitian operator.
+
+        Parameters
+        ----------
+        sectors : Sectors
+            Sectors in which operator should be constructed.
+        terms : dict
+            Terms of the model in which operator should be constructed.
+        sparsity : typing.Literal["sparse", "dense"]
+            Matrix sparsity type which is used, by default "dense".
+            If "sparse" is selected, returns matrix in CSR format.
+        dtype : npt.DTypeLike
+            Any object that can be interpreted as a numpy data type.
+
+        Returns
+        -------
+        np.ndarray | nps.csr_array
+            Constructed hermitian operator.
+
+        Raises
+        ------
+        ValueError
+            When provided `sparsity` is not supported.
+        """
+        shape = (sectors.size, sectors.size)
+        match sparsity:
+            case "dense":
+                matrix = np.zeros(shape, dtype=dtype)
+                HermitianOperator.__build_local_sectors(sectors, terms, matrix)
+                HermitianOperator.__build_mixing_sectors(sectors, terms, matrix)
+                matrix = matrix + np.conjugate(np.triu(matrix, 1)).T
+                return matrix
+
+            case "sparse":
+                matrix = nps.dok_array(shape, dtype=dtype)
+                HermitianOperator.__build_local_sectors(sectors, terms, matrix)
+                HermitianOperator.__build_mixing_sectors(sectors, terms, matrix)
+                matrix = nps.csr_array(matrix + nps.triu(matrix, 1).H)
+                return matrix
+
+            case _:
+                raise ValueError()

--- a/pystrel/operators/impl.py
+++ b/pystrel/operators/impl.py
@@ -1,0 +1,94 @@
+"""
+All `pystrel.operators.operator.Operator` implementations.
+"""
+import typing
+import numpy.typing as npt
+import numpy as np
+import scipy.sparse as nps  # type: ignore
+
+from ..sectors import Sectors
+from .operator import Operator
+from .hermitian_operator import HermitianOperator
+
+# pylint: disable=C0103, R0903
+
+
+class Operator_H(Operator):
+    r"""
+    Hamiltonian operator
+
+    $$
+        H = \sum_{ij} h_{ij}
+    $$
+    """
+    tag = "H"
+    name = "Hamiltonian"
+    repr = "H"
+
+    @staticmethod
+    def build(
+        sectors: Sectors,
+        terms: dict,
+        sparsity: typing.Literal["sparse", "dense"] = "dense",
+        dtype: npt.DTypeLike = None,
+        **kwargs,
+    ) -> np.ndarray | nps.csr_array:
+        return HermitianOperator.build(sectors, terms, sparsity, dtype)
+
+
+class Operator_N(Operator):
+    r"""
+    Total particle number operator, given by
+
+    $$
+        N = \sum_i n_i
+    $$
+    """
+    tag = "N"
+    name = "total particle number operator"
+    repr = "∑ᵢ nᵢ"
+
+    @staticmethod
+    def build(
+        sectors: Sectors,
+        terms: dict,
+        sparsity: typing.Literal["sparse", "dense"] = "dense",
+        dtype: npt.DTypeLike = None,
+        **kwargs,
+    ) -> np.ndarray | nps.csr_array:
+        return HermitianOperator.build(sectors, {"mu": 1}, sparsity, dtype)
+
+
+class Operator_n(Operator):
+    """
+    Particle number operator given by
+
+    $$
+        n_i.
+    $$
+
+    Parameters
+    ----------
+    **kwargs : dict, optional
+        `i`: select site.
+
+    """
+
+    tag = "n"
+    name = "particle number operator"
+    repr = "nᵢ"
+
+    @staticmethod
+    def build(
+        sectors: Sectors,
+        terms: dict,
+        sparsity: typing.Literal["sparse", "dense"] = "dense",
+        dtype: npt.DTypeLike = None,
+        **kwargs,
+    ) -> np.ndarray | nps.csr_array:
+        return HermitianOperator.build(
+            sectors, {"epsilon": {kwargs["i"]: 1.0}}, sparsity, dtype
+        )
+
+
+# pylint: enable=C0103, R0903

--- a/pystrel/operators/operator.py
+++ b/pystrel/operators/operator.py
@@ -1,0 +1,49 @@
+"""
+Template class for operator implementations.
+All implementations can be found here: `pystrel.operators.impl`.
+"""
+import typing
+import numpy.typing as npt
+import numpy as np
+import scipy.sparse as nps  # type: ignore
+from ..sectors import Sectors
+
+
+class Operator:  # pylint: disable=R0903
+    """Abstract class for operator implementations"""
+
+    tag: str
+    name: str
+    repr: str
+
+    @staticmethod  # pylint: disable=W0613
+    def build(
+        sectors: Sectors,
+        terms: dict,
+        sparsity: typing.Literal["sparse", "dense"] = "dense",
+        dtype: npt.DTypeLike = None,
+        **kwargs,
+    ) -> np.ndarray | nps.csr_array:
+        """
+        Construct matrix for given operator.
+
+        Parameters
+        ----------
+        sectors : Sectors
+            Sectors in which operator should be constructed.
+        terms : dict
+            Terms of the model in which operator should be constructed.
+        sparsity : typing.Literal["sparse", "dense"], optional
+            Matrix sparsity type which is used, by default "dense".
+            If "sparse" is selected, returns matrix in CSR format.
+        dtype : npt.DTypeLike, optional
+            Any object that can be interpreted as a numpy data type.
+        **kwargs : dict, optional
+            Additional operators arguments.
+
+        Returns
+        -------
+        np.ndarray | nps.csr_array
+            Constructed operator.
+        """
+        raise NotImplementedError()

--- a/pystrel/operators/utils.py
+++ b/pystrel/operators/utils.py
@@ -1,0 +1,87 @@
+"""
+Utilities related to operators.
+"""
+import typing
+import inspect
+import sys
+import numpy as np
+import numpy.typing as npt
+import scipy.sparse as nps  # type: ignore
+from . import impl
+from .operator import Operator
+from ..sectors import Sectors
+
+__tag_to_operator: dict[str, typing.Type[Operator]] = {}
+
+
+def build(
+    tag: str,
+    sectors: Sectors,
+    terms: dict,
+    sparsity: typing.Literal["dense", "sparse"],
+    dtype: npt.DTypeLike,
+    **kwargs,
+) -> np.ndarray | nps.csr_array:
+    """
+    Construct operator with the given `tag`.
+
+    Parameters
+    ----------
+    tag : str
+        Corresponding `tag` for operator to create.
+    sectors : Sectors
+        Sectors in which operator should be constructed.
+    terms : dict
+        Terms of the model in which operator should be constructed.
+    sparsity : typing.Literal["sparse", "dense"]
+        Matrix sparsity type which is used, by default "dense".
+        If "sparse" is selected, returns matrix in CSR format.
+    dtype : npt.DTypeLike
+        Any object that can be interpreted as a numpy data type.
+    **kwargs : dict, optional
+        Additional operators arguments.
+
+    Returns
+    -------
+    np.ndarray | nps.csr_array
+        Constructed operator.
+    """
+    return __tag_to_operator[tag].build(sectors, terms, sparsity, dtype, **kwargs)
+
+
+class _DuplicateTagError(Exception):  # pylint: disable=C0115
+    pass
+
+
+def register_term_type(operator_type: type):
+    """
+    Registers given `operator_type` in global mappings
+    used in `pystrel.operators.utils`.
+
+    Parameters
+    ----------
+    operator_type : type
+        Operator type to register. It should inherit from `pystrel.operators.operator.Operator`.
+
+    Raises
+    ------
+    _DuplicateTagError
+        when tag for given `operator_type` is already used.
+    """
+    assert issubclass(operator_type, Operator)
+
+    tag = operator_type.tag
+
+    if tag in __tag_to_operator:
+        raise _DuplicateTagError(
+            f"Duplicate tag is found: `{tag}`! "
+            f"Operators `{operator_type.__name__}` and `{__tag_to_operator[tag].__name__}`"
+            f" have the same tag `{tag}`."
+        )
+
+    __tag_to_operator[tag] = operator_type
+
+
+for name, obj in inspect.getmembers(sys.modules[impl.__name__]):
+    if inspect.isclass(obj) and issubclass(obj, Operator) and obj != Operator:
+        register_term_type(obj)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,0 +1,119 @@
+import pytest
+import numpy as np
+import numpy.testing as npt
+from pystrel import operators
+from pystrel.sectors import Sectors
+
+# pylint: disable=C0103,W0223,R0903,C0115
+
+
+def test_hermitian_operator_dense():
+    sectors = Sectors({"sectors": [(2, 0), (2, 1), (2, 2)]})
+    terms = {
+        "t": {(0, 1): 1.0 + 1.0j},
+        "Delta": {(0, 1): 0.5j},
+    }
+
+    h = operators.HermitianOperator.build(
+        sectors, terms, sparsity="dense", dtype=np.complex128
+    )
+
+    npt.assert_array_equal(h, np.conj(h.T))
+
+
+def test_hermitian_operator_sparse():
+    sectors = Sectors({"sectors": [(2, 0), (2, 1), (2, 2)]})
+    terms = {
+        "t": {(0, 1): 1.0 + 1.0j},
+        "Delta": {(0, 1): 0.5j},
+    }
+
+    h = operators.HermitianOperator.build(
+        sectors, terms, sparsity="sparse", dtype=np.complex128
+    )
+
+    npt.assert_array_equal(h.toarray(), h.conj().T.toarray())
+
+
+def test_operator_not_implemented():
+    class Fake(operators.Operator):
+        ...
+
+    sectors = Sectors({"sectors": [(2, 0), (2, 1), (2, 2)]})
+    terms = {
+        "t": {(0, 1): 1.0 + 1.0j},
+        "Delta": {(0, 1): 0.5j},
+    }
+
+    with pytest.raises(NotImplementedError):
+        Fake.build(sectors, terms)
+
+
+def test_hermitian_operator_throw():
+    sectors = Sectors({"sectors": [(2, 0), (2, 1), (2, 2)]})
+    terms = {
+        "t": {(0, 1): 1.0 + 1.0j},
+        "Delta": {(0, 1): 0.5j},
+    }
+
+    with pytest.raises(ValueError):
+        _ = operators.HermitianOperator.build(
+            sectors, terms, sparsity="qwerty", dtype=np.complex128
+        )
+
+
+def test_utils_duplicated_tag():
+    class FakeA(operators.Operator):
+        tag = "fake"
+
+    class FakeB(operators.Operator):
+        tag = "fake"
+
+    with pytest.raises(operators.utils._DuplicateTagError):  # pylint: disable=W0212
+        operators.utils.register_term_type(FakeA)
+        operators.utils.register_term_type(FakeB)
+
+
+def test_operator_H():
+    sectors = Sectors({"sectors": [(2, 0), (2, 1), (2, 2)]})
+    terms = {"t": {(0, 1): 1.0}}
+
+    h = operators.Operator_H.build(sectors, terms)
+
+    eig = np.linalg.eigvalsh(h, "U")
+    npt.assert_array_equal(eig, [-1, 0, 0, 1])
+
+
+def test_operator_N():
+    sectors = Sectors({"sectors": [(3, 0), (3, 1), (3, 3)]})
+    terms = {"t": {(0, 1): 1.0}}
+
+    N = operators.Operator_N.build(sectors, terms)
+
+    eig = np.linalg.eigvalsh(N, "U")
+    npt.assert_array_equal(eig, [0, 1, 1, 1, 3])
+
+
+def test_operator_n():
+    sectors = Sectors({"sectors": [(3, 0), (3, 1), (3, 3)]})
+    terms = {"t": {(0, 1): 1.0}}
+
+    n = operators.Operator_n.build(sectors, terms, i=1)
+
+    eig = np.linalg.eigvalsh(n, "U")
+    npt.assert_array_equal(eig, [0, 0, 0, 1, 1])
+
+
+def test_operator_Nn():
+    sectors = Sectors({"sectors": [(3, 0), (3, 1), (3, 3)]})
+    terms = {"t": {(0, 1): 1.0}}
+
+    N = operators.Operator_N.build(sectors, terms)
+    Ni = np.zeros((5, 5))
+    for i in range(3):
+        Ni += operators.Operator_n.build(sectors, terms, i=i)
+
+    npt.assert_array_equal(N, Ni)
+
+
+# pylint: enable=C0103,W0223,R0903,C0115


### PR DESCRIPTION
Add `operators` module within a few operators implementations, including:

- $H$ Hamiltonian,
- $N=\sum_i n_i$ total particle number operator,
- $n_i$ particle number operator.

`Model` class has been refactored, and for now it allows for operators, as well as Hamiltonian ,construction.