### PR TITLE
feat: laboratory measure utility

### DIFF
--- a/pystrel/__init__.py
+++ b/pystrel/__init__.py
@@ -3,5 +3,6 @@ from .model import Model
 from . import combinadics
 from . import terms
 from . import operators
+from .laboratory import measure
 
 __version__ = "0.0.0"

--- a/pystrel/laboratory.py
+++ b/pystrel/laboratory.py
@@ -1,0 +1,31 @@
+"""
+The laboratory module contains utilities related to the measurement of quantum states.
+"""
+import typing
+import numpy as np
+import scipy.sparse as nps  # type: ignore
+
+
+def measure(
+    operator: np.ndarray | nps.csr_array | typing.Any, state: np.ndarray
+) -> np.float64 | typing.Any:
+    r"""
+    Measure `operator` $A$ in a `state` $|\psi\rangle$
+
+    $$
+        \langle \psi | A | \psi \rangle.
+    $$
+
+    Parameters
+    ----------
+    operator : np.ndarray | nps.csr_array | typing.Any
+        Operator instance (sparse/dense/gpu/cpu)
+    state : np.ndarray
+        State instance (cpu/gpu)
+
+    Returns
+    -------
+    np.float64
+        Operator measurement.
+    """
+    return np.conj(state) @ operator @ state

--- a/tests/test_laboratory.py
+++ b/tests/test_laboratory.py
@@ -1,0 +1,23 @@
+import pytest
+import numpy as np
+import scipy.sparse as nps  # type: ignore
+import pystrel as ps
+
+
+@pytest.mark.parametrize(
+    "operator, state, expected",
+    [
+        (np.array([[0, 1], [1, 0]]), np.array([1, 0]), 0.0),
+        (np.array([[0, 1], [1, 0]]), np.array([1, 1]), 2.0),
+        (nps.csr_array(np.array([[0, 1], [1, 0]])), np.array([1, 0]), 0.0),
+        (nps.csr_array(np.array([[0, 1], [1, 0]])), np.array([1, 1]), 2.0),
+        (np.array([[0, 1.0j], [-1.0j, 0]]), np.array([1 + 1.0j, 1 - 1.0j]), 4.0 + 0.0j),
+        (
+            nps.csr_array(np.array([[0, 1.0j], [-1.0j, 0]])),
+            np.array([1 + 1.0j, 1 - 1.0j]),
+            4.0 + 0.0j,
+        ),
+    ],
+)
+def test_measure(operator, state, expected):
+    assert ps.measure(operator, state) == expected


### PR DESCRIPTION
Add utility for operators measurement in state `|psi>`, i.e. `<A>`.