### PR TITLE
fix: issue with sparse memory

### DIFF
--- a/pystrel/operators/hermitian_operator.py
+++ b/pystrel/operators/hermitian_operator.py
@@ -16,7 +16,7 @@ class HermitianOperator:  # pylint: disable=R0903
 
     @staticmethod
     def __build_local_sectors(
-        sectors: Sectors, terms: Terms, matrix: np.ndarray | nps.dok_array
+        sectors: Sectors, terms: Terms, matrix: np.ndarray | nps.lil_array
     ):
         for start, end, sector in sectors:
             matrix[start:end, start:end] = terms_utils.apply(
@@ -28,7 +28,7 @@ class HermitianOperator:  # pylint: disable=R0903
 
     @staticmethod
     def __build_mixing_sectors(
-        sectors: Sectors, terms: Terms, matrix: np.ndarray | nps.dok_array
+        sectors: Sectors, terms: Terms, matrix: np.ndarray | nps.lil_array
     ):
         for (start0, end0, sector0), (
             start1,
@@ -85,7 +85,7 @@ class HermitianOperator:  # pylint: disable=R0903
                 return matrix
 
             case "sparse":
-                matrix = nps.dok_array(shape, dtype=dtype)
+                matrix = nps.lil_array(shape, dtype=dtype)
                 HermitianOperator.__build_local_sectors(sectors, terms, matrix)
                 HermitianOperator.__build_mixing_sectors(sectors, terms, matrix)
                 matrix = nps.csr_array(matrix + nps.triu(matrix, 1).H)

--- a/pystrel/terms/impl.py
+++ b/pystrel/terms/impl.py
@@ -247,9 +247,8 @@ class Term_mu(Term):
         if isinstance(matrix, np.ndarray):
             np.fill_diagonal(matrix, matrix.diagonal() + params * sector[1])
 
-        elif isinstance(matrix, nps.dok_array):
-            diagonal = range(matrix.shape[0])
-            matrix[diagonal, diagonal] += params * sector[1]
+        elif isinstance(matrix, nps.lil_array):
+            matrix.setdiag(matrix.diagonal() + params * sector[1])
 
         return matrix
 

--- a/pystrel/terms/term.py
+++ b/pystrel/terms/term.py
@@ -19,7 +19,7 @@ class Term:  # pylint: disable=R0903
     @staticmethod  # pylint: disable=W0613
     def apply(
         params: dict | typing.Any,
-        matrix: np.ndarray | nps.dok_array,
+        matrix: np.ndarray | nps.lil_array,
         sector: tuple[int, int],
     ):
         """
@@ -32,7 +32,7 @@ class Term:  # pylint: disable=R0903
         ----------
         params : dict
             Dictionary of given parameters, e.g. `{(0, 1): 1.0, (1, 2): 2.0}`.
-        matrix : npt.ndarray | nps.dok_array
+        matrix : npt.ndarray | nps.lil_array
             View on matrix on which terms should be applied.
         sector : tuple[int, int]
             Corresponding particle sector for given `matrix`.

--- a/pystrel/terms/utils.py
+++ b/pystrel/terms/utils.py
@@ -129,10 +129,10 @@ def collect_mixing_sector_ranks(terms: Terms) -> set[int]:
 
 def apply(
     terms: Terms,
-    matrix: np.ndarray | nps.dok_array,
+    matrix: np.ndarray | nps.lil_array,
     sector: tuple[int, int],
     rank: int,
-) -> np.ndarray | nps.dok_array:
+) -> np.ndarray | nps.lil_array:
     """
     Applies all `terms` of given `rank` on `matrix` within given `sector`.
 
@@ -141,7 +141,7 @@ def apply(
     terms : Terms
         Dictionary with terms.
         See `pystrel.terms` for more details.
-    matrix : _type_
+    matrix : np.ndarray | nps.lil_array
         View on matrix on which terms should be applied.
     sector : tuple[int, int]
         Corresponding particle sector for given `matrix`.
@@ -150,7 +150,7 @@ def apply(
 
     Returns
     -------
-    np.ndarray | nps.dok_array
+    np.ndarray | nps.lil_array
         Matrix with applied terms.
     """
     for t, params in terms.items():

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -338,7 +338,7 @@ def test_term_mu_sparse():
     N = 2
     size = int(sps.binom(L, N))
     params = 2.0
-    matrix = nps.dok_array((size, size))
+    matrix = nps.lil_array((size, size))
     matrix.setdiag(np.arange(size))
 
     matrix = ps.Term_mu.apply(params, matrix, (L, N))


### PR DESCRIPTION
This commit addresses a problem related to memory usage in the codebase. The issue stemmed from the usage of `dok_array` in internal operator creations, which was replaced with `lil_array`. The previous implementation, using `dok_array`, resulted in memory spikes when slicing operations were performed, due to its behavior of casting to a dense array. The replacement with `lil_array` mitigates this problem and ensures more efficient memory utilization.